### PR TITLE
Fix two bugs around monitor/mwait

### DIFF
--- a/bochs/cpu/access2.cc
+++ b/bochs/cpu/access2.cc
@@ -304,7 +304,14 @@ BX_CPU_C::tickle_read_linear(unsigned s, bx_address laddr)
   bx_TLB_entry *tlbEntry = BX_DTLB_ENTRY_OF(laddr, 0);
   if (tlbEntry->lpf == lpf) {
     // See if the TLB entry privilege level allows us read access from this CPL
-    if (isReadOK(tlbEntry, USER_PL)) return;
+    if (isReadOK(tlbEntry, USER_PL)) {
+      BX_CPU_THIS_PTR address_xlation.paddress1 = tlbEntry->ppf | PAGE_OFFSET(laddr);
+      BX_CPU_THIS_PTR address_xlation.pages     = 1;
+#if BX_SUPPORT_MEMTYPE
+      BX_CPU_THIS_PTR address_xlation.memtype1  = tlbEntry->get_memtype();
+#endif
+      return;
+    }
   }
 
 #if BX_SUPPORT_X86_64

--- a/bochs/cpu/paging.cc
+++ b/bochs/cpu/paging.cc
@@ -394,7 +394,7 @@ void BX_CPU_C::TLB_flush(void)
 #if BX_SUPPORT_MONITOR_MWAIT
   // invalidating of the TLB might change translation for monitored page
   // and cause subsequent MWAIT instruction to wait forever
-  BX_CPU_THIS_PTR monitor.reset_monitor();
+  BX_CPU_THIS_PTR wakeup_monitor();
 #endif
 
   // break all links bewteen traces
@@ -415,7 +415,7 @@ void BX_CPU_C::TLB_flushNonGlobal(void)
 #if BX_SUPPORT_MONITOR_MWAIT
   // invalidating of the TLB might change translation for monitored page
   // and cause subsequent MWAIT instruction to wait forever
-  BX_CPU_THIS_PTR monitor.reset_monitor();
+  BX_CPU_THIS_PTR wakeup_monitor();
 #endif
 
   // break all links bewteen traces
@@ -435,7 +435,7 @@ void BX_CPU_C::TLB_invlpg(bx_address laddr)
 #if BX_SUPPORT_MONITOR_MWAIT
   // invalidating of the TLB entry might change translation for monitored
   // page and cause subsequent MWAIT instruction to wait forever
-  BX_CPU_THIS_PTR monitor.reset_monitor();
+  BX_CPU_THIS_PTR wakeup_monitor();
 #endif
 
   // break all links bewteen traces


### PR DESCRIPTION
MONITOR relies on tickle_read_virtual to set the physical address, but it was
only doing so on TLB miss. So a MONITOR with a TLB hit would arm the most
recently accessed address instead of the requested one.

TLB invalidations disarmed the monitoring range, but didn't wake a CPU that
had already MWAIT-ed. Any instruction that invalidated TLB entries on other
CPUs could have caused an MWAIT-ing CPU to never wake.