### PR TITLE
Fix that the INIT signal remains pending even after delivery of VM-exit/#VMEXIT(INIT)

### DIFF
--- a/bochs/cpu/event.cc
+++ b/bochs/cpu/event.cc
@@ -161,7 +161,7 @@ void BX_CPU_C::VirtualInterruptAcknowledge(void)
 
   BX_CPU_THIS_PTR EXT = 1; /* external event */
 
-  BX_INSTR_HWINTERRUPT(BX_CPU_ID, vector, 
+  BX_INSTR_HWINTERRUPT(BX_CPU_ID, vector,
       BX_CPU_THIS_PTR sregs[BX_SEG_REG_CS].selector.value, RIP);
   interrupt(vector, BX_EXTERNAL_INTERRUPT, 0, 0);
 
@@ -305,7 +305,7 @@ bool BX_CPU_C::handleAsyncEvent(void)
     }
 #endif
     clear_event(BX_EVENT_NMI);
-     mask_event(BX_EVENT_NMI);
+    mask_event(BX_EVENT_NMI);
     BX_CPU_THIS_PTR EXT = 1; /* external event */
 #if BX_SUPPORT_VMX
     VMexit_Event(BX_NMI, 2, 0, 0);

--- a/bochs/cpu/event.cc
+++ b/bochs/cpu/event.cc
@@ -231,6 +231,7 @@ bool BX_CPU_C::handleAsyncEvent(void)
   }
 
   if (is_unmasked_event_pending(BX_EVENT_INIT) && SVM_GIF) {
+    clear_event(BX_EVENT_INIT);
 #if BX_SUPPORT_SVM
     if (BX_CPU_THIS_PTR in_svm_guest) {
       if (SVM_INTERCEPT(SVM_INTERCEPT0_INIT)) Svm_Vmexit(SVM_VMEXIT_INIT);
@@ -241,7 +242,6 @@ bool BX_CPU_C::handleAsyncEvent(void)
       VMexit(VMX_VMEXIT_INIT, 0);
     }
 #endif
-    // reset will clear pending INIT
     reset(BX_RESET_SOFTWARE);
 
 #if BX_SUPPORT_SMP


### PR DESCRIPTION
Fixes an issue discussed in #11. Also contains minor cosmetic changes in the same file.

The rough steps to reproduce the issue is:
1. build bochs with --enable-smp
2. configure a VM with 2 processors, and use it to OSVM BIOS ie, romimage: file="/usr/share/ovmf/OVMF.fd"...
3. boot into the UEFI shell (that must be deployed onto some storage)
4. load a program (hypervisor) that puts all logical processors into VMX non-root operation
5. try to up APs again with INIT-SIPI-SIPI. The easiest is to use UEFI's Multiprocessor Protocol.

Bochs log.
```
...
01138561688i[APIC1 ] Deliver INIT IPI
01138602990i[CPU0  ] RDMSR: Read 00000000:fee00900 from MSR_APICBASE
01138604256i[CPU0  ] RDMSR: Read 00000000:fee00900 from MSR_APICBASE
01138604279i[APIC1 ] Deliver Start Up IPI
01138606451i[CPU0  ] RDMSR: Read 00000000:fee00900 from MSR_APICBASE
01138607207i[CPU0  ] RDMSR: Read 00000000:fee00900 from MSR_APICBASE
01138607218i[APIC1 ] Deliver Start Up IPI
01138607218i[CPU1  ] CPU 1 started up by APIC, but was not halted at that time
```

Trace of VM-exits after (5)
```
[E] HandleVmExit: VM-exit reason (Full) = 00000003
[E] HandleVmExit: VM-exit reason (Full) = 00000004
[E] HandleVmExit: VM-exit reason (Full) = 00000003        << spurious INIT VM-exit 
```
In this particular case, the system freezes as the AP never successfully started (and BSP waited for it)

To be clear, I did not test it for AMD, but looking at code, the same issue appears to exist, and this change appears to be safe even if the issue does not exists.