### PR TITLE
Ignore MSVC/Visual Studio build related files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 *.lo
 *.a
 *.la
+obj-debug/
+obj-release/
 
 # /bochs/
 /bochs/Makefile
@@ -27,6 +29,7 @@
 /bochs/ltdlconf.h
 /bochs/libtool
 /bochs/.bochs.out
+/bochs/vs2019
 
 # /bochs/bios/
 /bochs/bios/Makefile


### PR DESCRIPTION
Those directories are created when you follow the documented build steps (`sh .conf.win32-vcpp` and `make win32_snap`) and work with those generated files on Visual Studio. They can contain more than 1000 of files which can make tracking changed files difficult for no good.