### PR TITLE
Add .gitattributes force eol to LF (no CR+LF)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
People have different core.autocrlf configurations and It can turn Bochs repository into a mess.

text="auto" is for automatic end-of-line normalization. If Git decides that the content is text, its line endings are normalized to LF on checkin.

If the text attribute is unspecified, Git uses the core.autocrlf configuration variable to determine if the file should be converted.

So, when someone commits a file, Git guesses whether that file is a text file or not, and if it is, it will commit a version of the file where all CR + LF bytes are replaced with LF bytes.